### PR TITLE
Fix some cppcheck reports:

### DIFF
--- a/ma_desc.c
+++ b/ma_desc.c
@@ -84,14 +84,14 @@ MADB_Desc *MADB_DescInit(MADB_Dbc *Dbc,enum enum_madb_desc_type DescType, my_boo
   if (my_init_dynamic_array(&Desc->Records, sizeof(MADB_DescRecord), 0, 0))
   {
     MADB_FREE(Desc);
-    Desc= NULL;
+    return NULL;
   }
   if (Desc && isExternal)
   {
     if (my_init_dynamic_array(&Desc->Stmts, sizeof(MADB_Stmt**), 0, 0))
     {
       MADB_DescFree(Desc, FALSE);
-      Desc= NULL;
+      return NULL;
     }
     else
     {
@@ -101,11 +101,8 @@ MADB_Desc *MADB_DescInit(MADB_Dbc *Dbc,enum enum_madb_desc_type DescType, my_boo
       Dbc->Descrs= list_add(Dbc->Descrs, &Desc->ListItem);
     }
   }
-  if (Desc)
-  {
-    Desc->AppType= isExternal;
-    Desc->Header.ArraySize= 1;
-  }
+  Desc->AppType= isExternal;
+  Desc->Header.ArraySize= 1;
  
   return Desc;
 }

--- a/ma_desc.c
+++ b/ma_desc.c
@@ -86,7 +86,7 @@ MADB_Desc *MADB_DescInit(MADB_Dbc *Dbc,enum enum_madb_desc_type DescType, my_boo
     MADB_FREE(Desc);
     return NULL;
   }
-  if (Desc && isExternal)
+  if (isExternal)
   {
     if (my_init_dynamic_array(&Desc->Stmts, sizeof(MADB_Stmt**), 0, 0))
     {

--- a/ma_desc.c
+++ b/ma_desc.c
@@ -86,7 +86,7 @@ MADB_Desc *MADB_DescInit(MADB_Dbc *Dbc,enum enum_madb_desc_type DescType, my_boo
     MADB_FREE(Desc);
     Desc= NULL;
   }
-  if (isExternal)
+  if (Desc && isExternal)
   {
     if (my_init_dynamic_array(&Desc->Stmts, sizeof(MADB_Stmt**), 0, 0))
     {
@@ -102,9 +102,10 @@ MADB_Desc *MADB_DescInit(MADB_Dbc *Dbc,enum enum_madb_desc_type DescType, my_boo
     }
   }
   if (Desc)
+  {
     Desc->AppType= isExternal;
-
-  Desc->Header.ArraySize= 1;
+    Desc->Header.ArraySize= 1;
+  }
  
   return Desc;
 }

--- a/ma_parse.c
+++ b/ma_parse.c
@@ -42,8 +42,6 @@ MADB_QUERY *MADB_Tokenize(const char *Stmt)
   const char *End= (char *)Stmt + strlen(Stmt);
   const char *Pos;
   const char *Start= Stmt;
-  const char *p= Stmt;
-  int Tokens= 0;
 
   MADB_QUERY *Query= (MADB_QUERY *)MADB_CALLOC(sizeof(MADB_QUERY));
   init_dynamic_array(&Query->tokens, sizeof(unsigned int), 20, 20);

--- a/ma_statement.c
+++ b/ma_statement.c
@@ -1309,10 +1309,9 @@ end:
 SQLRETURN MADB_StmtBindCol(MADB_Stmt *Stmt, SQLUSMALLINT ColumnNumber, SQLSMALLINT TargetType,
     SQLPOINTER TargetValuePtr, SQLLEN BufferLength, SQLLEN *StrLen_or_Ind)
 {
-  MADB_Desc *Ard = Stmt->Ard;
+  MADB_Desc *Ard= Stmt->Ard;
   MADB_DescRecord *Record;
 
-  Ard= Stmt->Ard;
   if ((ColumnNumber < 1 && Stmt->Options.UseBookmarks == SQL_UB_OFF) || 
       (mysql_stmt_field_count(Stmt->stmt) &&
        Stmt->stmt->state > MYSQL_STMT_PREPARED && 

--- a/ma_statement.c
+++ b/ma_statement.c
@@ -1309,12 +1309,9 @@ end:
 SQLRETURN MADB_StmtBindCol(MADB_Stmt *Stmt, SQLUSMALLINT ColumnNumber, SQLSMALLINT TargetType,
     SQLPOINTER TargetValuePtr, SQLLEN BufferLength, SQLLEN *StrLen_or_Ind)
 {
-  MADB_Desc *Ard;
+  MADB_Desc *Ard = Stmt->Ard;
   MADB_DescRecord *Record;
 
-  if (!Stmt)
-    return SQL_INVALID_HANDLE;
-  
   Ard= Stmt->Ard;
   if ((ColumnNumber < 1 && Stmt->Options.UseBookmarks == SQL_UB_OFF) || 
       (mysql_stmt_field_count(Stmt->stmt) &&

--- a/ma_statement.c
+++ b/ma_statement.c
@@ -110,8 +110,6 @@ SQLRETURN MADB_ExecuteQuery(MADB_Stmt * Stmt, char *StatementText, SQLINTEGER Te
 /* {{{ MADB_StmtBulkOperations */
 SQLRETURN MADB_StmtBulkOperations(MADB_Stmt *Stmt, SQLSMALLINT Operation)
 {
-  SQLHSTMT NewStmt= NULL;
-
   MADB_CLEAR_ERROR(&Stmt->Error);
   switch(Operation)
   {
@@ -441,7 +439,6 @@ SQLRETURN MADB_StmtPrepare(MADB_Stmt *Stmt, char *StatementText, SQLINTEGER Text
 
   if ((CursorName = MADB_ParseCursorName(Stmt, &WhereOffset)))
   {
-    unsigned int Length= WhereOffset + 10;
     DYNAMIC_STRING StmtStr;
     char *TableName;
 
@@ -1312,12 +1309,13 @@ end:
 SQLRETURN MADB_StmtBindCol(MADB_Stmt *Stmt, SQLUSMALLINT ColumnNumber, SQLSMALLINT TargetType,
     SQLPOINTER TargetValuePtr, SQLLEN BufferLength, SQLLEN *StrLen_or_Ind)
 {
-  MADB_Desc *Ard= Stmt->Ard;
+  MADB_Desc *Ard;
   MADB_DescRecord *Record;
 
   if (!Stmt)
     return SQL_INVALID_HANDLE;
   
+  Ard= Stmt->Ard;
   if ((ColumnNumber < 1 && Stmt->Options.UseBookmarks == SQL_UB_OFF) || 
       (mysql_stmt_field_count(Stmt->stmt) &&
        Stmt->stmt->state > MYSQL_STMT_PREPARED && 
@@ -1795,13 +1793,15 @@ SQLRETURN MADB_FixFetchedValues(MADB_Stmt *Stmt, int RowNumber, MYSQL_ROWS *Save
 SQLRETURN MADB_StmtFetch(MADB_Stmt *Stmt, my_bool KeepPosition)
 {
   unsigned int j, rc;
-  SQLULEN      ArraySize=  Stmt->Ard->Header.ArraySize;
-  MADB_Desc   *ArdDesc=    Stmt->Ard;
+  SQLULEN      ArraySize;
+  MADB_Desc   *ArdDesc;
   MYSQL_ROWS  *SaveCursor= NULL;
     
   if (!Stmt || !Stmt->stmt)
     return SQL_INVALID_HANDLE;
 
+  ArraySize=  Stmt->Ard->Header.ArraySize;
+  ArdDesc= Stmt->Ard;
   MADB_CLEAR_ERROR(&Stmt->Error);
 
   if ((Stmt->Options.UseBookmarks == SQL_UB_VARIABLE && Stmt->Options.BookmarkType != SQL_C_VARBOOKMARK) ||

--- a/ma_statement.c
+++ b/ma_statement.c
@@ -1789,15 +1789,13 @@ SQLRETURN MADB_FixFetchedValues(MADB_Stmt *Stmt, int RowNumber, MYSQL_ROWS *Save
 SQLRETURN MADB_StmtFetch(MADB_Stmt *Stmt, my_bool KeepPosition)
 {
   unsigned int j, rc;
-  SQLULEN      ArraySize;
-  MADB_Desc   *ArdDesc;
+  SQLULEN      ArraySize=  Stmt->Ard->Header.ArraySize;
+  MADB_Desc   *ArdDesc= Stmt->Ard;
   MYSQL_ROWS  *SaveCursor= NULL;
     
-  if (!Stmt || !Stmt->stmt)
+  if (!Stmt->stmt)
     return SQL_INVALID_HANDLE;
 
-  ArraySize=  Stmt->Ard->Header.ArraySize;
-  ArdDesc= Stmt->Ard;
   MADB_CLEAR_ERROR(&Stmt->Error);
 
   if ((Stmt->Options.UseBookmarks == SQL_UB_VARIABLE && Stmt->Options.BookmarkType != SQL_C_VARBOOKMARK) ||

--- a/ma_string.c
+++ b/ma_string.c
@@ -85,7 +85,7 @@ my_bool MADB_DynStrAppendQuoted(DYNAMIC_STRING *DynString, char *String)
 
 my_bool MADB_DynStrUpdateSet(MADB_Stmt *Stmt, DYNAMIC_STRING *DynString)
 {
-  int             i, IgnoredColumns= 0, Count= 0;
+  int             i, IgnoredColumns= 0;
   MADB_DescRecord *Record;
 
   if (dynstr_append(DynString, " SET "))


### PR DESCRIPTION
[ma_desc.c:107] -> [ma_desc.c:104]: (warning) Either the condition 'Desc' is redundant or there is possible null pointer dereference: Desc.
[ma_parse.c:45]: (style) Variable 'p' is assigned a value that is never used.
[ma_parse.c:46]: (style) Variable 'Tokens' is assigned a value that is never used.
[ma_statement.c:113]: (style) Variable 'NewStmt' is assigned a value that is never used.
[ma_statement.c:444]: (style) Variable 'Length' is assigned a value that is never used.
[ma_statement.c:1315] -> [ma_statement.c:1318]: (warning) Either the condition '!Stmt' is redundant or there is possible null pointer dereference: Stmt.
[ma_statement.c:1798] -> [ma_statement.c:1802]: (warning) Either the condition '!Stmt' is redundant or there is possible null pointer dereference: Stmt.
[ma_statement.c:1799] -> [ma_statement.c:1802]: (warning) Either the condition '!Stmt' is redundant or there is possible null pointer dereference: Stmt.
[ma_string.c:88]: (style) Variable 'Count' is assigned a value that is never used.