### PR TITLE
Return correct scale for SQL_C_NUMERIC

### DIFF
--- a/ma_helper.c
+++ b/ma_helper.c
@@ -1045,7 +1045,7 @@ int MADB_CharToSQLNumeric(char *buffer, MADB_Desc *Ard, MADB_DescRecord *ArdReco
       
       memcpy(digits + digits_count, dot + 1, digits_significant);
       digits_count+= digits_significant;
-
+      number->scale= digits_significant;
     } else 
     {
       char *start= p;


### PR DESCRIPTION
If a specific value has less digits after the decimal point than were requested then make sure we update the returned scale to indicate how many digits are actually being returned.