### PR TITLE
Fix bug in ABI analogous to [ODBC-123]

### DIFF
--- a/ma_connection.c
+++ b/ma_connection.c
@@ -1212,7 +1212,7 @@ SQLRETURN MADB_DbcGetInfo(MADB_Dbc *Dbc, SQLUSMALLINT InfoType, SQLPOINTER InfoV
     break;
   }
   case SQL_GROUP_BY:
-    MADB_SET_NUM_VAL(SQLUINTEGER, InfoValuePtr, SQL_GB_NO_RELATION, StringLengthPtr);
+    MADB_SET_NUM_VAL(SQLUSMALLINT, InfoValuePtr, SQL_GB_NO_RELATION, StringLengthPtr);
     break;
   case SQL_IDENTIFIER_CASE:
     MADB_SET_NUM_VAL(SQLUINTEGER, InfoValuePtr, SQL_IC_MIXED, StringLengthPtr);


### PR DESCRIPTION
libreoffice base still crashing when creating new SQL Queries. ODBC doc says it wants 16 bit int here.