### PR TITLE
[ODBC-148] The field length is not set for DATE, TIME, or DATETIME va…

### DIFF
--- a/ma_helper.c
+++ b/ma_helper.c
@@ -804,9 +804,14 @@ SQLRETURN MADB_CopyMadbTimestamp(MADB_Stmt *Stmt, MYSQL_TIME *tm, MADB_Desc *Ard
       ts->minute= tm->minute;
       ts->second= tm->second;
       ts->fraction= tm->second_part * 1000;
-      if (ts->year + ts->month + ts->day + ts->hour + ts->minute + ts->fraction + ts->second == 0)
-        if (ArdRecord->IndicatorPtr)
-          *ArdRecord->IndicatorPtr= SQL_NULL_DATA;
+
+	  if (ArdRecord->IndicatorPtr)
+	  {
+		  if (ts->year + ts->month + ts->day + ts->hour + ts->minute + ts->fraction + ts->second == 0)
+			*ArdRecord->IndicatorPtr = SQL_NULL_DATA;
+		  else
+			*ArdRecord->IndicatorPtr = sizeof(SQL_TIMESTAMP_STRUCT);
+	  }
     }
     break;
     case SQL_C_TIME:
@@ -821,6 +826,9 @@ SQLRETURN MADB_CopyMadbTimestamp(MADB_Stmt *Stmt, MYSQL_TIME *tm, MADB_Desc *Ard
       ts->hour= tm->hour;
       ts->minute= tm->minute;
       ts->second= tm->second;
+
+	  if (ArdRecord->IndicatorPtr)
+		  *ArdRecord->IndicatorPtr = sizeof(SQL_TIME_STRUCT);
     }
     break;
     case SQL_C_DATE:
@@ -830,9 +838,14 @@ SQLRETURN MADB_CopyMadbTimestamp(MADB_Stmt *Stmt, MYSQL_TIME *tm, MADB_Desc *Ard
       ts->year= tm->year;
       ts->month= tm->month;
       ts->day= tm->day;
-      if (ts->year + ts->month + ts->day == 0)
-        if (ArdRecord->IndicatorPtr)
-          *ArdRecord->IndicatorPtr= SQL_NULL_DATA;
+
+	  if (ArdRecord->IndicatorPtr)
+	  {
+		  if (ts->year + ts->month + ts->day == 0)
+			  *ArdRecord->IndicatorPtr = SQL_NULL_DATA;
+		  else
+			  *ArdRecord->IndicatorPtr = sizeof(SQL_DATE_STRUCT);
+	  }
     }
     break;
   }


### PR DESCRIPTION
…lues assigned during SQLFetch calls

Without the length set, Crystal Reports interprets all DATE, TIME, and
DATETIME values as NULL.

Set *ArdRecord->IndicatorPtr to the size of the appropriate structure in
MADB_CopyMadbTimestamp.

Pull request submitted under the BSD-new license.