### PR TITLE
ODBC-207 Fix multi-statement param realloc

### DIFF
--- a/ma_statement.c
+++ b/ma_statement.c
@@ -1093,14 +1093,16 @@ SQLRETURN MADB_StmtExecute(MADB_Stmt *Stmt, BOOL ExecDirect)
         CurQuery+= strlen(CurQuery) + 1;
       }
       
-      Stmt->ParamCount= (SQLSMALLINT)mysql_stmt_param_count(Stmt->stmt);
       Stmt->RebindParams= TRUE;
 
-      if (StatementNr > 0)
+      if (Stmt->ParamCount != mysql_stmt_param_count(Stmt->stmt))
       {
+        Stmt->ParamCount= (SQLSMALLINT)mysql_stmt_param_count(Stmt->stmt);
         Stmt->params= (MYSQL_BIND*)MADB_REALLOC(Stmt->params, sizeof(MYSQL_BIND) * MADB_STMT_PARAM_COUNT(Stmt));
-        memset(Stmt->params, 0, sizeof(MYSQL_BIND) * MADB_STMT_PARAM_COUNT(Stmt));
       }
+
+      memset(Stmt->params, 0, sizeof(MYSQL_BIND) * MADB_STMT_PARAM_COUNT(Stmt));
+      
     }
 
     if (MADB_DOING_BULK_OPER(Stmt))

--- a/test/multistatement.c
+++ b/test/multistatement.c
@@ -90,9 +90,38 @@ ODBC_TEST(test_params)
 
   CHECK_STMT_RC(Stmt, SQLBindParameter(Stmt, 2, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 10, 0, &j, 0, NULL));
 
+
   for (i=0; i < 100; i++)
   {
     j= i + 100;
+    CHECK_STMT_RC(Stmt, SQLExecute(Stmt)); 
+
+    while (SQLMoreResults(Stmt) == SQL_SUCCESS);
+  }
+
+  return OK;
+}
+
+ODBC_TEST(test_params_last_count_smaller)
+{
+  int       i, j, k;
+
+  OK_SIMPLE_STMT(Stmt, "DROP TABLE IF EXISTS t1; CREATE TABLE t1(a int, b int)");
+
+  OK_SIMPLE_STMT(Stmt, "DROP TABLE IF EXISTS t2; CREATE TABLE t2(a int)");
+
+  CHECK_STMT_RC(Stmt, SQLPrepare(Stmt, "INSERT INTO t1 VALUES (?,?); INSERT INTO t2 VALUES (?)", SQL_NTS));
+
+  CHECK_STMT_RC(Stmt, SQLBindParameter(Stmt, 1, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 10, 0, &i, 0, NULL));
+
+  CHECK_STMT_RC(Stmt, SQLBindParameter(Stmt, 2, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 10, 0, &j, 0, NULL));
+
+  CHECK_STMT_RC(Stmt, SQLBindParameter(Stmt, 3, SQL_PARAM_INPUT, SQL_C_LONG, SQL_INTEGER, 10, 0, &k, 0, NULL));
+
+  for (i=0; i < 100; i++)
+  {
+    j= i + 100;
+    k= i + 1000;
     CHECK_STMT_RC(Stmt, SQLExecute(Stmt)); 
 
     while (SQLMoreResults(Stmt) == SQL_SUCCESS);
@@ -580,6 +609,7 @@ MA_ODBC_TESTS my_tests[]=
   {test_multi_statements, "test_multi_statements"},
   {test_multi_on_off, "test_multi_on_off"},
   {test_params, "test_params"},
+  {test_params_last_count_smaller, "test_params_last_count_smaller"},
   {t_odbc_16, "test_odbc_16"},
   {test_semicolon, "test_semicolon_in_string"},
   {t_odbc74, "t_odbc74and_odbc97"},


### PR DESCRIPTION
Example use case:
Prepare the following SQL statement:
"INSERT INTO tbl (a,b) VALUES (?,?); SELECT 1 FROM tbl WHERE c = ?"
First execution of prepared statement will work, second execution will segfault or cause memory corruption.

Fix is simply to reallocate parameter storage every time the number of parameters changes.