### PR TITLE
Fixed POSIX build error due to a type mismatch

### DIFF
--- a/ma_platform_posix.c
+++ b/ma_platform_posix.c
@@ -41,9 +41,9 @@ void InitializeCriticalSection(CRITICAL_SECTION *cs)
   pthread_mutex_init(cs, &attr);
 }
 
-SQLRETURN DSNPrompt_Lookup(MADB_Prompt *prompt, const char * SetupLibName)
+int DSNPrompt_Lookup(MADB_Prompt *prompt, const char * SetupLibName)
 {
-  return  MADB_PROMPT_NOT_SUPPORTED;
+  return MADB_PROMPT_NOT_SUPPORTED;
 }
 
 


### PR DESCRIPTION
After 9d2f2c8, the header was changed to return type `int` (see [here](https://github.com/MariaDB/mariadb-connector-odbc/commit/9d2f2c8421477d1d69086a09f5bedf1ae906fb17#diff-948024cb11277ce70058e57bd50953b2R411)), but the POSIX implementation was not changed accordingly.

Consider this submitted under the BSD-new licence.